### PR TITLE
More GameAssignment Enhancements

### DIFF
--- a/apps/acnw/playwright/game-assignments.spec.ts
+++ b/apps/acnw/playwright/game-assignments.spec.ts
@@ -60,11 +60,11 @@ test.describe.serial('Game assignments dashboard', () => {
 
     await expect(nightWatchRow).toBeVisible()
 
-    const overrunCell = nightWatchRow.getByRole('cell').nth(3)
-    const spacesCell = nightWatchRow.getByRole('cell').nth(5)
+    const overrunCell = nightWatchRow.locator('[data-cell-id$="_overrun"]')
+    const spacesCell = nightWatchRow.locator('[data-cell-id$="_spaces"]')
 
-    const parseCount = async (locator: ReturnType<typeof nightWatchRow.getByRole>) => {
-      const value = (await locator.textContent())?.trim() ?? '0'
+    const parseCount = async (cellLocator: typeof overrunCell) => {
+      const value = (await cellLocator.textContent())?.trim() ?? '0'
       return Number(value)
     }
 


### PR DESCRIPTION
https://github.com/ggascoigne/amber/issues/237: Show columns with 1st through 4th choices in the folded out game in Assignments by Game

https://github.com/ggascoigne/amber/issues/247: match / highlight players in unfolded Assignments by Game against Game Interest Reference

https://github.com/ggascoigne/amber/issues/252: Members with incomplete signups are now displayed in red in the Member Choices and Assignment By Member tables.

https://github.com/ggascoigne/amber/issues/241: Show min-max and Any|Pref|Ret in the Assignments by Game

https://github.com/ggascoigne/amber/issues/245: Show # of slots with a choice in Assignments by Member or Member Choices