### PR TITLE
Allow editing game choices in the GA page

### DIFF
--- a/packages/ui/components/Table/editing/TableCellEditor.tsx
+++ b/packages/ui/components/Table/editing/TableCellEditor.tsx
@@ -63,10 +63,13 @@ type TableOptionContent = {
   label: string
   columns?: Array<TableOptionColumn>
   isHeader?: boolean
+  fontWeight?: number
 }
 
 const renderOptionContent = (option: TableOptionContent) => {
-  if (!option.columns?.length) return option.label
+  if (!option.columns?.length) {
+    return <Box sx={{ fontWeight: option.isHeader ? 600 : option.fontWeight }}>{option.label}</Box>
+  }
 
   return (
     <Box
@@ -83,7 +86,7 @@ const renderOptionContent = (option: TableOptionContent) => {
         <Box
           key={`${index}-${column.value}`}
           sx={{
-            fontWeight: option.isHeader ? 600 : undefined,
+            fontWeight: option.isHeader ? 600 : option.fontWeight,
             color: option.isHeader ? 'text.secondary' : undefined,
             textAlign: column.align ?? (index === 0 ? 'left' : 'right'),
             overflow: 'hidden',

--- a/packages/ui/components/Table/editing/types.ts
+++ b/packages/ui/components/Table/editing/types.ts
@@ -14,6 +14,7 @@ export type TableEditOption = {
   columns?: Array<TableOptionColumn>
   disabled?: boolean
   isHeader?: boolean
+  fontWeight?: number
 }
 
 export type TableAutocompleteOption = {
@@ -22,6 +23,7 @@ export type TableAutocompleteOption = {
   columns?: Array<TableOptionColumn>
   disabled?: boolean
   isHeader?: boolean
+  fontWeight?: number
 }
 
 export type TableEditAutocompleteConfig<TData extends RowData> = {
@@ -31,12 +33,17 @@ export type TableEditAutocompleteConfig<TData extends RowData> = {
   isOptionEqual?: (option: TableAutocompleteOption, value: TableAutocompleteOption) => boolean
 }
 
+export type TableEditCellContext<TData extends RowData> = {
+  table: Table<TData>
+  getValue: (row: Row<TData>, columnId: string) => unknown
+}
+
 export type TableEditColumnConfig<TData extends RowData> = {
   type: TableEditColumnType
   options?: Array<TableEditOption>
   getOptions?: (row: Row<TData>) => Array<TableEditOption>
   autocomplete?: TableEditAutocompleteConfig<TData>
-  isEditable?: (row: Row<TData>) => boolean
+  isEditable?: (row: Row<TData>, context: TableEditCellContext<TData>) => boolean
   parseValue?: (value: string, row: Row<TData>) => unknown
   formatValue?: (value: unknown, row: Row<TData>) => string
   placeholder?: string


### PR DESCRIPTION
This allows editing of game choices via the Member Choice page.  It's not a pretty as the more member-facing version, but it's faster and doesn't require a context shift and annoying filtering.