### PR TITLE
Upgrade local Docker Postgres from 14 to 17

### DIFF
--- a/packages/server/docker-compose.yaml
+++ b/packages/server/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: amber-postgres
-    image: postgres:14-alpine
+    image: postgres:17-alpine
     restart: unless-stopped
     ports:
       - '54320:5432'


### PR DESCRIPTION
## Summary
- Bumps `packages/server/docker-compose.yaml` from `postgres:14-alpine` to `postgres:17-alpine`
- Fixes `pg_restore` failure when restoring prod dumps locally (`transaction_timeout` parameter unrecognized by Postgres 14)

## Test plan
- [x] Started container with Postgres 17, verified version
- [x] Ran `pnpm -F acus db:import` successfully

References: #273