### PR TITLE
Change game-assignments permission from GameAdmin to IsAdmin

### DIFF
--- a/apps/acnw/views/Routes.tsx
+++ b/apps/acnw/views/Routes.tsx
@@ -133,7 +133,7 @@ export const rootRoutes = (configuration: Configuration): RootRoutes => [
     path: '/game-assignments',
     label: 'Game Assignments',
     exact: true,
-    permission: Perms.GameAdmin,
+    permission: Perms.IsAdmin,
   },
   {
     path: '/member-admin',

--- a/apps/acus/views/Routes.tsx
+++ b/apps/acus/views/Routes.tsx
@@ -106,7 +106,7 @@ export const rootRoutes = (configuration: Configuration): RootRoutes => [
     path: '/game-assignments',
     label: 'Game Assignments',
     exact: true,
-    permission: Perms.GameAdmin,
+    permission: Perms.IsAdmin,
   },
   {
     path: '/member-admin',


### PR DESCRIPTION
## Summary

- Change the route permission for `/game-assignments` from `Perms.GameAdmin` to `Perms.IsAdmin` in both `acnw` and `acus` apps

## Test plan

- [x] Tested locally — verified game-assignments route requires IsAdmin permission

References: #279