### PR TITLE
Add downloadable Excel report for vouchers

### DIFF
--- a/apps/acus/pages/api/reports/voucherReport.ts
+++ b/apps/acus/pages/api/reports/voucherReport.ts
@@ -1,0 +1,46 @@
+import { getConfig, handleError, queryToExcelDownload } from '@amber/api'
+import { auth0 } from '@amber/server/src/auth/auth0'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default auth0.withApiAuthRequired(async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const configuration = await getConfig()
+    if (!configuration) throw new Error('Unable to load configuration')
+    const year = req.body?.year ?? configuration.year
+
+    const query = `
+      SELECT
+        u.full_name AS "Member",
+        CAST(m.attendance AS INTEGER) AS "Days Attending",
+        COALESCE(gm_counts.gm_slots, 0)::integer AS "GM Slots",
+        CASE
+          WHEN CAST(m.attendance AS INTEGER) = 3 THEN 15
+          WHEN CAST(m.attendance AS INTEGER) = 4 THEN 20
+          ELSE 0
+        END AS "Attendance Vouchers ($)",
+        (COALESCE(gm_counts.gm_slots, 0) * 5)::integer AS "GM Vouchers ($)",
+        (CASE
+          WHEN CAST(m.attendance AS INTEGER) = 3 THEN 15
+          WHEN CAST(m.attendance AS INTEGER) = 4 THEN 20
+          ELSE 0
+        END + COALESCE(gm_counts.gm_slots, 0) * 5)::integer AS "Total Vouchers ($)"
+      FROM
+        membership m
+        JOIN "user" u ON m.user_id = u.id
+        LEFT JOIN (
+          SELECT ga.member_id, COUNT(*) AS gm_slots
+          FROM game_assignment ga
+          WHERE ga.gm > 0 AND ga.year = ${year}
+          GROUP BY ga.member_id
+        ) gm_counts ON gm_counts.member_id = m.id
+      WHERE
+        m.year = ${year}
+        AND m.attending = true
+      ORDER BY
+        u.full_name
+      `
+    await queryToExcelDownload(query, res)
+  } catch (err: any) {
+    handleError(err, res)
+  }
+})

--- a/apps/acus/pages/report-admin.tsx
+++ b/apps/acus/pages/report-admin.tsx
@@ -19,6 +19,7 @@ const reports: ReportRecord[] = [
   { name: 'Rooms By Room' },
   { name: 'Rooms By Game' },
   { name: 'Game Assignments' },
+  { name: 'Voucher' },
 ]
 
 export const getServerSideProps = configGetServerSideProps


### PR DESCRIPTION
## Summary

- Adds a Voucher report to the ACUS report-admin page
- Lists all attending members alphabetically with Days Attending, GM Slots, Attendance Vouchers ($15 for 3 days, $20 for 4 days), GM Vouchers ($5 per slot), and Total Vouchers
- Numeric columns explicitly cast to integer for Excel summability

## Test plan

- [x] Download the Voucher report from report-admin
- [x] Verify members are listed alphabetically
- [x] Verify Days Attending matches membership attendance values
- [x] Verify GM Slots counts match game_assignment GM entries
- [x] Verify Attendance Vouchers: $15 for 3 days, $20 for 4 days, $0 otherwise
- [x] Verify GM Vouchers: $5 per GM slot
- [x] Verify Total Vouchers = Attendance Vouchers + GM Vouchers
- [x] Verify all numeric columns are summable in Excel

References: #282